### PR TITLE
Remove useless destructor and flag to enable the default move assignment

### DIFF
--- a/source/module_cell/module_neighbor/sltk_atom_arrange.cpp
+++ b/source/module_cell/module_neighbor/sltk_atom_arrange.cpp
@@ -163,29 +163,3 @@ void atom_arrange::search(
 
     return;
 }
-
-
-//2015-05-07
-void atom_arrange::delete_vector(
-	std::ofstream &ofs_in,
-	const bool pbc_flag, // GlobalV::SEARCH_PBC
-	Grid_Driver &grid_d, 
-	const UnitCell &ucell, 
-	const double &search_radius_bohr, 
-	const int &test_atom_in)
-{
-	const double radius_lat0unit2 = search_radius_bohr / ucell.lat0;
-
-	Atom_input at2(
-		ofs_in,
-		ucell, 
-		ucell.nat, 
-		ucell.ntype, 
-		pbc_flag, 
-		radius_lat0unit2, 
-		test_atom_in);
-
-	grid_d.delete_vector(at2.getGrid_layerX_minus(),at2.getGrid_layerY_minus(),at2.getGrid_layerZ_minus());
-
-	grid_d.delete_Cell();
-}

--- a/source/module_cell/module_neighbor/sltk_atom_arrange.h
+++ b/source/module_cell/module_neighbor/sltk_atom_arrange.h
@@ -30,17 +30,6 @@ public:
 		const double& rcutmax_Beta, 
 		const bool gamma_only_local);
 
-	//2015-05-07
-	static void delete_vector(
-		std::ofstream &ofs_in,
-		const bool pbc_flag,
-		Grid_Driver &grid_d, 
-		const UnitCell &ucell, 
-		const double &search_radius_bohr, 
-		const int &test_atom_in);
-
-private:
-
 };
 
 #endif

--- a/source/module_cell/module_neighbor/sltk_grid.cpp
+++ b/source/module_cell/module_neighbor/sltk_grid.cpp
@@ -16,20 +16,9 @@ CellSet::CellSet()
     in_grid[2] = 0;
 }
 
-Grid::Grid(const int& test_grid_in) : test_grid(test_grid_in)
-{
-    //	ModuleBase::TITLE("Grid","Grid");
-    //----------------------------------------------------------
-    // EXPLAIN : init_cell_flag (use this flag in case memory
-    // leak)
-    //----------------------------------------------------------
-    init_cell_flag = false;
-}
+Grid::Grid(const int& test_grid_in) : test_grid(test_grid_in) {}
 
-Grid::~Grid()
-{
-    this->delete_Cell();
-}
+Grid::~Grid() {}
 
 void Grid::init(std::ofstream& ofs_in, const UnitCell& ucell, const Atom_input& input)
 {
@@ -49,7 +38,6 @@ void Grid::setMemberVariables(std::ofstream& ofs_in, //  output data to ofs
 {
     ModuleBase::TITLE("SLTK_Grid", "setMemberVariables");
 
-    this->delete_Cell();
     // mohan add 2010-09-05
     // AdjacentSet::call_times = 0;
 
@@ -96,8 +84,6 @@ void Grid::setMemberVariables(std::ofstream& ofs_in, //  output data to ofs
             Cell[i][j].resize(cell_nz);
         }
     }
-    this->init_cell_flag = true;
-
     this->true_cell_x = input.getGrid_layerX_minus();
     this->true_cell_y = input.getGrid_layerY_minus();
     this->true_cell_z = input.getGrid_layerZ_minus();
@@ -506,16 +492,5 @@ void Grid::Construct_Adjacent_final(const int i,
     if (dr != 0.0 && dr <= this->sradius2)
     {
         fatom1.addAdjacent(fatom2);
-    }
-}
-// 2015-05-07
-void Grid::delete_vector(int i, int j, int k)
-{
-    if (expand_flag)
-    {
-        if (this->pbc)
-        {
-            this->Cell[i][j][k].atom_map.clear();
-        }
     }
 }

--- a/source/module_cell/module_neighbor/sltk_grid.h
+++ b/source/module_cell/module_neighbor/sltk_grid.h
@@ -41,10 +41,9 @@ class Grid
     Grid(const int& test_grid_in);
     virtual ~Grid();
 
-    void init(std::ofstream& ofs, const UnitCell& ucell, const Atom_input& input);
+    Grid& operator=(Grid&&) = default;
 
-    // 2015-05-07
-    void delete_vector(int i, int j, int k);
+    void init(std::ofstream& ofs, const UnitCell& ucell, const Atom_input& input);
 
     // Data
     bool pbc; // periodic boundary condition
@@ -64,28 +63,7 @@ class Grid
     int true_cell_z;
 
     std::vector<std::vector<std::vector<CellSet>>> Cell; // dx , dy ,dz is cell number in each direction,respectly.
-    void delete_Cell()                                   // it will replace by container soon!
-    {
-        if (this->init_cell_flag)
-        {
-            for (int i = 0; i < this->cell_nx; i++)
-            {
-                for (int j = 0; j < this->cell_ny; j++)
-                {
-                    this->Cell[i][j].clear();
-                }
-            }
 
-            for (int i = 0; i < this->cell_nx; i++)
-            {
-                this->Cell[i].clear();
-            }
-
-            this->Cell.clear();
-            this->init_cell_flag = false;
-        }
-    }
-    bool init_cell_flag = false;
     // LiuXh add 2019-07-15
     double getD_minX() const
     {
@@ -125,8 +103,8 @@ class Grid
         return true_cell_z;
     }
 
-  private:
-    const int test_grid;
+private:
+    int test_grid = 0;
     //==========================================================
     // MEMBER FUNCTIONS :
     // Three Main Steps:

--- a/source/module_cell/module_neighbor/sltk_grid_driver.h
+++ b/source/module_cell/module_neighbor/sltk_grid_driver.h
@@ -55,6 +55,8 @@ class Grid_Driver : public Grid
 
     ~Grid_Driver();
 
+    Grid_Driver& operator=(Grid_Driver&&) = default;
+
     //==========================================================
     // EXPLAIN FOR default parameter `adjs = nullptr`
     //
@@ -103,7 +105,7 @@ class Grid_Driver : public Grid
   private:
     mutable AdjacentAtomInfo adj_info;
 
-    const int test_deconstructor; // caoyu reconst 2021-05-24
+    int test_deconstructor = 0;
 
     //==========================================================
     // MEMBER FUNCTIONS :

--- a/source/module_cell/module_neighbor/test/sltk_atom_arrange_test.cpp
+++ b/source/module_cell/module_neighbor/test/sltk_atom_arrange_test.cpp
@@ -52,7 +52,6 @@ Magnetism::~Magnetism()
 void SetGlobalV()
 {
     PARAM.input.test_grid = false;
-    PARAM.input.test_deconstructor = false;
 }
 
 class SltkAtomArrangeTest : public testing::Test

--- a/source/module_cell/module_neighbor/test/sltk_grid_test.cpp
+++ b/source/module_cell/module_neighbor/test/sltk_grid_test.cpp
@@ -84,7 +84,6 @@ TEST_F(SltkGridTest, Init)
     Atom_input Atom_inp(ofs, *ucell, ucell->nat, ucell->ntype, pbc, radius, test_atom_in);
     Grid LatGrid(PARAM.input.test_grid);
     LatGrid.init(ofs, *ucell, Atom_inp);
-    EXPECT_TRUE(LatGrid.init_cell_flag);
     EXPECT_EQ(LatGrid.getCellX(), 11);
     EXPECT_EQ(LatGrid.getCellY(), 11);
     EXPECT_EQ(LatGrid.getCellZ(), 11);
@@ -126,9 +125,6 @@ TEST_F(SltkGridTest, InitSmall)
     EXPECT_EQ(LatGrid.cell_nx, 4);
     EXPECT_EQ(LatGrid.cell_ny, 4);
     EXPECT_EQ(LatGrid.cell_nz, 4);
-    // init cell flag
-    EXPECT_TRUE(LatGrid.init_cell_flag);
-
     ofs.close();
     remove("test.out");
 }

--- a/source/module_esolver/esolver_lj.cpp
+++ b/source/module_esolver/esolver_lj.cpp
@@ -88,15 +88,6 @@ void ESolver_LJ::runner(UnitCell& ucell, const int istep)
             lj_virial(i, j) /= (2.0 * ucell.omega);
         }
     }
-#ifdef __MPI
-        atom_arrange::delete_vector(
-            GlobalV::ofs_running,
-            PARAM.inp.search_pbc,
-            grid_neigh,
-            ucell, 
-            search_radius,
-            PARAM.inp.test_atom_input);
-#endif
     }
 
     double ESolver_LJ::cal_energy()

--- a/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/tmp_mocks.cpp
+++ b/source/module_hamilt_lcao/hamilt_lcaodft/operator_lcao/test/tmp_mocks.cpp
@@ -174,7 +174,8 @@ Grid::Grid(const int& test_grid_in) : test_grid(test_grid_in) {}
 Grid::~Grid() {}
 Grid_Driver::Grid_Driver(const int& test_d_in,
                          const int& test_grid_in)
-    : Grid(test_grid_in), test_deconstructor(test_d_in) {}
+    : Grid(test_grid_in), test_deconstructor(test_d_in) {
+}
 Grid_Driver::~Grid_Driver() {}
 
 // filter_adjs delete not adjacent atoms in adjs

--- a/source/module_lr/esolver_lrtd_lcao.cpp
+++ b/source/module_lr/esolver_lrtd_lcao.cpp
@@ -146,6 +146,8 @@ LR::ESolver_LR<T, TR>::ESolver_LR(ModuleESolver::ESolver_KS_LCAO<T, TR>&& ks_sol
         throw std::invalid_argument("when lr_solver==spectrum, esolver_type must be set to `lr` to skip the KS calculation.");
 }
 
+    this->gd = std::move(ks_sol.gd);
+
     // xc kernel
     this->xc_kernel = inp.xc_kernel;
     std::transform(xc_kernel.begin(), xc_kernel.end(), xc_kernel.begin(), tolower);


### PR DESCRIPTION
If we don't do this change, the default move assignment will cause segment fault in the destructor due to visiting the moved vector elements in such redundant "delete" functions.
Even if no move assignment, vector members do not need to be manually cleared in the destructor, as is well-known. 

I've checked by valgrind that this change does not induce memory leak.